### PR TITLE
v0.2.0

### DIFF
--- a/Common.cmake
+++ b/Common.cmake
@@ -41,6 +41,7 @@
       - print
       - print_var
       - print_var_with
+      - create_symlink_to_compile_commands
 
   Usage:
 
@@ -403,6 +404,21 @@ endmacro()
 macro(print_var_with variable hint)
   message("${hint}: ${variable} = \"${${variable}}\"")
 endmacro()
+
+#[=============================================================================[
+  Create a symbolic link in `${PROJECT_SOURCE_DIR}/build/` directory to
+  `compile_commands.json` if `${PROJECT_SOURCE_DIR}/build/` itself is not
+  the project binary directory.
+#]=============================================================================]
+function(create_symlink_to_compile_commands)
+  if (NOT PROJECT_BINARY_DIR STREQUAL "${PROJECT_SOURCE_DIR}/build")
+    file(MAKE_DIRECTORY "${PROJECT_SOURCE_DIR}/build")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+      "${PROJECT_BINARY_DIR}/compile_commands.json"
+      "${PROJECT_SOURCE_DIR}/build/compile_commands.json"
+    )
+  endif()
+endfunction()
 
 
 ########################### The end of the listfile ############################

--- a/Common.cmake
+++ b/Common.cmake
@@ -18,6 +18,7 @@
   Commands:
     * Guards:
       - no_in_source_builds_guard
+      - requires_cmake
     * Watchers:
       - mark_command_as_deprecated (3.18+, see details)
       - mark_normal_variable_as_deprecated
@@ -132,6 +133,20 @@ function(no_in_source_builds_guard)
       "Windows (PowerShell): Remove-Item CMakeFiles, CMakeCache.txt, cmake_install.cmake -force -recurse\n"
       "Windows (Command Prompt): rmdir CMakeFiles /s /q && del /q CMakeCache.txt cmake_install.cmake\n"
       "NOTE: Build generator files may also remain, that is, 'Makefile', 'build.ninja' and so forth.\n"
+    )
+  endif()
+endfunction()
+
+#[=============================================================================[
+  Check if CMake's version is not less than ${version}, otherwise, print
+  the error message with ${reason}. It may be useful if building in the
+  developer mode needs higher CMake's version than building to only install
+  the project.
+#]=============================================================================]
+function(requires_cmake version reason)
+  if (CMAKE_VERSION VERSION_LESS "${version}")
+    message(FATAL_ERROR
+      "CMake ${version}+ is required because of the reason \"${reason}\", but the current version is ${CMAKE_VERSION}."
     )
   endif()
 endfunction()

--- a/DeveloperMode.cmake
+++ b/DeveloperMode.cmake
@@ -11,6 +11,7 @@
 include_guard(GLOBAL)
 
 
+include_project_module(dependencies/PythonVenv)
 include_project_module(dependencies/Testing)
 include_project_module(dependencies/Benchmarking)
 include_project_module(dependencies/Coverage)

--- a/Externals.cmake
+++ b/Externals.cmake
@@ -13,8 +13,10 @@ cxx_standard_guard()
 
 
 include_project_module(dependencies/Docs)
-add_docs_if_enabled(docs FORMAT html
-  INPUTS
-    include
-    README.md
-)
+if (ENABLE_DOCS)
+  add_docs(docs FORMAT html
+    INPUTS
+      include
+      README.md
+  )
+endif()

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ git subtree --squash --prefix=cmake pull cmake-modules main
 
 License
 -------
-This CMake modules are distributed under the [MIT License](./LICENSE), but other projects that use this modules can have its own license.
+These CMake modules are distributed under the [MIT License](./LICENSE), but other projects that use this modules can have its own license.
 
 Extra materials
 ---------------

--- a/Variables.cmake
+++ b/Variables.cmake
@@ -53,6 +53,8 @@ project_option(ENABLE_TREATING_INCLUDES_AS_SYSTEM
 )
 if (ENABLE_TREATING_INCLUDES_AS_SYSTEM)
   project_cached_variable(WARNING_GUARD "SYSTEM" STRING "Warning guard")
+else()
+  project_cached_variable(WARNING_GUARD "" STRING "Warning guard")
 endif()
 
 

--- a/Variables.cmake
+++ b/Variables.cmake
@@ -43,19 +43,15 @@ project_option(ENABLE_CCACHE "Enable ccache" OFF)
 
 #[=============================================================================[
   Enable treating the project's include directories as system via passing the
-  `SYSTEM` option to the `target_include_directories` command. This may have
-  effects such as suppressing warnings or skipping the contained headers in
-  dependency calculations (see compiler documentation).
+  `SYSTEM` option to the `target_include_directories` command inside the
+  `project_target_include_directories` command. This may have effects such as
+  suppressing warnings or skipping the contained headers in dependency
+  calculations (see compiler documentation).
 #]=============================================================================]
 project_option(ENABLE_TREATING_INCLUDES_AS_SYSTEM
   "Use the `SYSTEM` option for the project's includes, compilers may disable warnings"
   ON IF (NOT PROJECT_IS_TOP_LEVEL)
 )
-if (ENABLE_TREATING_INCLUDES_AS_SYSTEM)
-  project_cached_variable(WARNING_GUARD "SYSTEM" STRING "Warning guard")
-else()
-  project_cached_variable(WARNING_GUARD "" STRING "Warning guard")
-endif()
 
 
 ############################## Developer options ###############################

--- a/Variables.cmake
+++ b/Variables.cmake
@@ -70,6 +70,7 @@ project_dev_option(ENABLE_TESTING "Enable testing")
 project_cached_variable(TEST_DIR "tests" PATH "Testing directory")
 
 project_dev_option(ENABLE_BENCHMARKING "Enable benchmarking")
+project_dev_option(ENABLE_BENCHMARK_TOOLS "Enable benchmark tools")
 project_cached_variable(BENCHMARK_DIR "benchmarks" PATH "Benchmarking directory")
 
 project_dev_option(ENABLE_COVERAGE "Enable code coverage testing")

--- a/Variables.cmake
+++ b/Variables.cmake
@@ -78,6 +78,14 @@ project_dev_option(ENABLE_FORMATTING "Enable code formatting")
 
 # TODO: implement other developer options
 
+if (ENABLE_DEVELOPER_MODE)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "Generate `compile_commands.json`")
+
+  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    create_symlink_to_compile_commands()
+  endif()
+endif()
+
 
 ##################### Project non-boolean cached variables #####################
 

--- a/Variables.cmake
+++ b/Variables.cmake
@@ -86,6 +86,14 @@ if (ENABLE_DEVELOPER_MODE)
   endif()
 endif()
 
+project_option(ENABLE_PYTHON_VENV "Enable creating of Python virtual environment"
+  # Specify other conditions, if any
+  ON IF ENABLE_BENCHMARKING
+)
+project_cached_variable(PYTHON_VENV_DIR
+  "${PROJECT_SOURCE_DIR}/.venv" PATH
+  "Python virtual environment directory"
+)
 
 ##################### Project non-boolean cached variables #####################
 

--- a/compiler/Common.cmake
+++ b/compiler/Common.cmake
@@ -39,11 +39,13 @@
     add_subdirectory(externals)
 
     add_project_library(my_library)
-    target_link_libraries(my_project_name_my_library
-      PUBLIC my_project_name_cxx_standard
+    project_target_link_libraries(my_library
+      PUBLIC
+        my_project_name::cxx_standard
     )
-    target_compile_options(my_project_name_my_library
-      PRIVATE ${CXX_OPTIONS}
+    project_target_compile_options(my_library
+      PRIVATE
+        ${CXX_OPTIONS}
     )
     # other target commands
 

--- a/compiler/CxxOptions.cmake
+++ b/compiler/CxxOptions.cmake
@@ -15,23 +15,9 @@ else()
   include_project_module(compiler/Gnu.CxxOptions)
 endif()
 
-add_project_library(cxx_warning_options INTERFACE)
-target_compile_options(${cxx_warning_options} INTERFACE ${CXX_WARNING_OPTIONS})
-
-add_project_library(cxx_error_options INTERFACE)
-target_compile_options(${cxx_error_options} INTERFACE ${CXX_ERROR_OPTIONS})
-
-add_project_library(cxx_language_options INTERFACE)
-target_compile_options(${cxx_language_options} INTERFACE ${CXX_LANGUAGE_OPTIONS})
-
-add_project_library(cxx_diagnostic_options INTERFACE)
-target_compile_options(${cxx_diagnostic_options} INTERFACE ${CXX_DIAGNOSTIC_OPTIONS})
-
-add_project_library(cxx_options INTERFACE)
-target_link_libraries(${cxx_options}
-  INTERFACE
-    ${cxx_warning_options}
-    ${cxx_error_options}
-    ${cxx_language_options}
-    ${cxx_diagnostic_options}
+# Include `CXX_ERROR_OPTIONS` explicitly
+list(APPEND CXX_OPTIONS
+  ${CXX_WARNING_OPTIONS}
+  ${CXX_LANGUAGE_OPTIONS}
+  ${CXX_DIAGNOSTIC_OPTIONS}
 )

--- a/compiler/Gnu.CxxOptions.cmake
+++ b/compiler/Gnu.CxxOptions.cmake
@@ -60,6 +60,8 @@ set(CXX_ERROR_OPTIONS
   -Wno-error=non-virtual-dtor
 )
 
+set(CXX_LANGUAGE_OPTIONS "")
+
 set(CXX_DIAGNOSTIC_OPTIONS
   # See: https://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Message-Formatting-Options.html
 

--- a/dependencies/Benchmarking.cmake
+++ b/dependencies/Benchmarking.cmake
@@ -42,4 +42,27 @@ if (NOT benchmark_FOUND)
   FetchContent_MakeAvailable(benchmark)
 endif(NOT benchmark_FOUND)
 
+if (ENABLE_BENCHMARK_TOOLS)
+  if (NOT DEFINED benchmark_SOURCE_DIR)
+    set(benchmark_SOURCE_DIR "")
+  endif()
+
+  find_path(benchmark_tools
+    NAMES
+      "compare.py"
+    HINTS
+      "/usr/share/benchmark"
+      "${benchmark_SOURCE_DIR}/tools"
+  )
+  mark_as_advanced(benchmark_tools)
+  if (NOT benchmark_tools)
+    message(FATAL_ERROR "Benchmark tools is not found.")
+  endif()
+
+  find_or_init_python_venv()
+  pip3_install(-r "${benchmark_tools}/requirements.txt")
+  # Even though, `requirements.txt` doesn't have `pandas`, `compare.py` still requires it
+  pip3_install(wheel pandas)
+endif(ENABLE_BENCHMARK_TOOLS)
+
 add_subdirectory(${BENCHMARK_DIR})

--- a/dependencies/Docs.cmake
+++ b/dependencies/Docs.cmake
@@ -24,15 +24,16 @@
 include_guard(GLOBAL)
 
 
-#[=============================================================================[
-  If the documentation is enabled, add the target for building the documentation
-  of files that can be recursively found in the `INPUTS` parameters and to place
-  the result in the `OUTPUT` parameter.
+enable_if_project_variable_is_set(ENABLE_DOCS)
 
-    add_docs_if_enabled(<target_alias>
-                        FORMAT <format>
-                        INPUTS <files or directories> ...
-                        [OUTPUT <output_directory>])
+#[=============================================================================[
+  Add the target for building the documentation of files that can be recursively
+  found in the `INPUTS` parameters and to place the result in the `OUTPUT`
+  parameter.
+
+    add_docs(<target_alias> FORMAT <format>
+             INPUTS <files or directories> ...
+             [OUTPUT <output_directory>])
 
   The true target name is `${namespace}_${target_alias}` with defined
   `${target_alias}` variable set to the target name.
@@ -43,7 +44,7 @@ include_guard(GLOBAL)
 
   Also generate install rules for documentation if `${ENABLE_INSTALL}` is set.
 #]=============================================================================]
-function(add_docs_if_enabled target_alias)
+function(add_docs target_alias)
   set(options "")
   set(one_value_keywords FORMAT OUTPUT)
   set(multi_value_keywords INPUTS)
@@ -52,8 +53,6 @@ function(add_docs_if_enabled target_alias)
     "${one_value_keywords}"
     "${multi_value_keywords}"
   )
-
-  enable_if_project_variable_is_set(ENABLE_DOCS)
 
   if (NOT ARGS_OUTPUT)
     string(TOLOWER ${ARGS_FORMAT} ARGS_OUTPUT)
@@ -86,10 +85,9 @@ function(add_docs_if_enabled target_alias)
       "${INSTALL_DOC_DIR}"
     COMPONENT "${namespace}_docs" EXCLUDE_FROM_ALL
   )
+  add_component_target(${namespace}_docs)
 endfunction()
 
-
-enable_if_project_variable_is_set(ENABLE_DOCS)
 
 ################## Initialization the documentation generator ##################
 

--- a/dependencies/PythonVenv.cmake
+++ b/dependencies/PythonVenv.cmake
@@ -1,0 +1,97 @@
+#[=============================================================================[
+  Author: Pavel Tsayukov
+  Distributed under the MIT License. See accompanying file LICENSE or
+  https://opensource.org/license/mit for details.
+  ------------------------------------------------------------------------------
+  Python virtual environment creation (3.15+)
+  ------------------------------------------------------------------------------
+  Enable the `${NAMESPACE}_ENABLE_PYTHON_VENV` project option to turn this
+  module on. Then find and create, if needed, Python virtual environment in
+  `${${NAMESPACE}_PYTHON_VENV_DIR}`. See `../Variables.cmake` for details.
+
+  Commands:
+    - find_or_init_python_venv
+    - pip2_install
+    - pip3_install
+
+#]=============================================================================]
+
+include_guard(GLOBAL)
+
+
+enable_if_project_variable_is_set(ENABLE_PYTHON_VENV)
+requires_cmake(3.15 "Using `*_FIND_VIRTUALENV` in FindPython2 or FindPython3 modules")
+
+#[=============================================================================[
+  Try to find Python virtual environment in `${PYTHON_VENV_DIR}`. If there's no
+  any, find Python and create its virtual environment. By default, use Python 3
+  that was found by `find_package`. Otherwise, pass the specific version:
+
+    find_or_init_python_venv([<version>] [<other find_package parameters>...])
+
+  While passing parameters to this command, Python version must be the first
+  one, otherwise, an error will be raised.
+#]=============================================================================]
+macro(find_or_init_python_venv)
+  if ("${ARGC}" EQUAL "0")
+    __find_or_init_python_venv_impl(Python3 REQUIRED ${ARGN})
+  elseif ("${ARGV0}" MATCHES "^3")
+    __find_or_init_python_venv_impl(Python3 REQUIRED ${ARGN})
+  elseif ("${ARGV0}" MATCHES "^2")
+    __find_or_init_python_venv_impl(Python2 REQUIRED ${ARGN})
+  else()
+    message(FATAL_ERROR "Python version must be the first parameter.")
+  endif()
+endmacro()
+
+function(pip2_install)
+  execute_process(COMMAND ${Python2_EXECUTABLE} -m pip install ${ARGN})
+endfunction()
+
+function(pip3_install)
+  execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install ${ARGN})
+endfunction()
+
+
+################################ Implementation ################################
+
+function(__init_virtual_env_variable)
+  file(TO_NATIVE_PATH "${PYTHON_VENV_DIR}" python_venv_native_path)
+  # Mimic the `bin/activate` script to help `find_package` find the venv
+  # See: https://docs.python.org/3/library/venv.html#how-venvs-work
+  set(ENV{VIRTUAL_ENV} "${python_venv_native_path}")
+endfunction()
+
+macro(__find_or_init_python_venv_impl)
+  if (("${ARGC}" EQUAL "0") OR (NOT "${ARGV0}" MATCHES "^Python(2|3)$"))
+    message(FATAL_ERROR "Missing \"Python2\" or \"Python3\" argument!")
+  endif()
+
+  __init_virtual_env_variable()
+  find_package(${ARGN})
+
+  if (NOT ${ARGV0}_EXECUTABLE MATCHES "^$ENV{VIRTUAL_ENV}/")
+    message(STATUS "Creating ${ARGV0} virtual environment in \"$ENV{VIRTUAL_ENV}\"")
+    execute_process(COMMAND
+        ${${ARGV0}_EXECUTABLE} -m venv "$ENV{VIRTUAL_ENV}"
+      WORKING_DIRECTORY
+        "${benchmark_compare_py}"
+    )
+    message(STATUS "Creating ${ARGV0} virtual environment in \"$ENV{VIRTUAL_ENV}\" - done")
+
+    # Force `find_package` to run another search
+    unset(${ARGV0}_EXECUTABLE)
+
+    # Change the context of search
+    # See: https://cmake.org/cmake/help/latest/module/FindPython2.html
+    # See: https://cmake.org/cmake/help/latest/module/FindPython3.html
+    set(${ARGV0}_FIND_VIRTUALENV "FIRST")
+
+    find_package(${ARGN})
+    if (NOT ${ARGV0}_EXECUTABLE MATCHES "^$ENV{VIRTUAL_ENV}/")
+      message(FATAL_ERROR "${ARGV0} virtual environment is not found!")
+    endif()
+  endif()
+
+  message(STATUS "Found ${ARGV0} (venv): ${${ARGV0}_EXECUTABLE}")
+endmacro()

--- a/install/Common.cmake
+++ b/install/Common.cmake
@@ -69,10 +69,12 @@ function(install_project_cmake_configs)
 
   list(APPEND ARGS_PATH_VARS "INSTALL_CMAKE_DIR")
 
+  set(no_set_and_check_macro "")
   if (ARGS_NO_SET_AND_CHECK_MACRO)
     set(no_set_and_check_macro "NO_SET_AND_CHECK_MACRO")
   endif()
 
+  set(no_check_required_components_macro "")
   if (ARGS_NO_CHECK_REQUIRED_COMPONENTS_MACRO)
     set(no_check_required_components_macro "NO_CHECK_REQUIRED_COMPONENTS_MACRO")
   endif()

--- a/install/Common.cmake
+++ b/install/Common.cmake
@@ -204,10 +204,13 @@ function(install_project_targets)
     message(FATAL_ERROR "The `TARGETS` parameters must have at least one target.")
   endif()
 
+  set(target_list "")
   foreach (target IN LISTS ARGS_TARGETS)
+    __get_project_target_name(${target})
     if (NOT TARGET ${target})
       message(FATAL_ERROR "`${target}` is not a target.")
     endif()
+    list(APPEND target_list ${target})
   endforeach()
 
   set(artifact_options "")
@@ -229,7 +232,7 @@ function(install_project_targets)
   endif()
 
   install(TARGETS
-      ${ARGS_TARGETS}
+      ${target_list}
     EXPORT "${PACKAGE_EXPORT_TARGET_NAME}"
     ${artifact_options}
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"

--- a/install/Common.cmake
+++ b/install/Common.cmake
@@ -150,7 +150,12 @@ function(install_project_headers)
     COMPONENT "${namespace}_headers"
     FILES_MATCHING
       PATTERN "*.h"
+      PATTERN "*.hh"
+      PATTERN "*.h++"
       PATTERN "*.hpp"
+      PATTERN "*.hxx"
+      PATTERN "*.in"
+      PATTERN "*.inc"
   )
 endfunction()
 

--- a/install/Common.cmake
+++ b/install/Common.cmake
@@ -4,6 +4,16 @@
   https://opensource.org/license/mit for details.
   ------------------------------------------------------------------------------
   Installation commands
+  ------------------------------------------------------------------------------
+  Commands:
+    * Installation:
+      - install_project_cmake_configs
+      - install_project_license
+      - install_project_headers
+      - install_project_targets
+    * Auxiliary commands:
+      - add_component_target
+
 #]=============================================================================]
 
 include_guard(GLOBAL)
@@ -112,6 +122,7 @@ function(install_project_cmake_configs)
     DESTINATION "${INSTALL_CMAKE_DIR}"
     COMPONENT "${namespace}_configs"
   )
+  add_component_target(${namespace}_configs)
 endfunction()
 
 # Install the LICENSE file to `${INSTALL_LICENSE_DIR}`
@@ -157,6 +168,7 @@ function(install_project_headers)
       PATTERN "*.in"
       PATTERN "*.inc"
   )
+  add_component_target(${namespace}_headers)
 endfunction()
 
 #[=============================================================================[
@@ -212,6 +224,8 @@ function(install_project_targets)
         DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         COMPONENT "${namespace}_development"
     )
+    add_component_target(${namespace}_runtime)
+    add_component_target(${namespace}_development)
   endif()
 
   install(TARGETS
@@ -227,4 +241,37 @@ function(install_project_targets)
     DESTINATION "${INSTALL_CMAKE_DIR}"
     COMPONENT "${namespace}_configs"
   )
+  add_component_target(${namespace}_configs)
+endfunction()
+
+
+############################## Auxiliary commands ##############################
+
+#[=============================================================================[
+  Add the custom target for an install ${component} to use it in build presets:
+
+    {
+      "name": "install_docs",
+      ...
+      "targets": "install_my_project_docs"
+    }
+
+  So the command below could run installation of the project documentation:
+
+    cmake --build --preset install_docs
+
+  If the custom target already exists, do nothing.
+#]=============================================================================]
+function(add_component_target component)
+  if (NOT TARGET install_${component})
+    add_custom_target(install_${component}
+      COMMAND
+        # `cmake --install` works only in 3.15+
+        ${CMAKE_COMMAND} -DCOMPONENT=${component} -P "cmake_install.cmake"
+      WORKING_DIRECTORY
+        "${PROJECT_BINARY_DIR}"
+      COMMENT
+        "Installing ${component} component..."
+    )
+  endif()
 endfunction()


### PR DESCRIPTION
Issue #20

Changelog:
- Removed short aliases for project targets due to a [bug](https://github.com/tsayukov/cmake-modules/issues/2). Instead of that feature, added `project_target_*` commands, that are, `target_*` command's counterparts, which can take `${namespace}::<target_suffix>` as well as the short names of project targets and regular targets (in this precedence). The `install_project_targets` command works the similar way now.
- Removed `cxx_*_options` targets, which include corresponding compile options, due to [invalid behavior](https://github.com/tsayukov/cmake-modules/issues/3). Now use `CXX_OPTIONS` variable and a family of `CXX_*_OPTIONS` variables instead. Note that `CXX_ERROR_OPTIONS` is not a part of `CXX_OPTIONS` anymore. Include it manually.
- Install component can be used in CMake presets now. See a new `add_component_target` command for details.
- Added Python virtual environment support. See `PythonVenv` module for details.
- Added [google benchmark tools](https://github.com/google/benchmark/blob/main/docs/tools.md) support. See `Benchmarking` module for details.
- `CMAKE_EXPORT_COMPILE_COMMANDS` is turned on in the developer mode now. Also a symlink to `compile_commands.json` is created in `build` directory, if there's no any.
- Added a new `requires_cmake` command.
- Improved some documentation.