### PR TITLE
v0.3.0

### DIFF
--- a/dependencies/Docs.cmake
+++ b/dependencies/Docs.cmake
@@ -31,12 +31,11 @@ enable_if_project_variable_is_set(ENABLE_DOCS)
   found in the `INPUTS` parameters and to place the result in the `OUTPUT`
   parameter.
 
-    add_docs(<target_alias> FORMAT <format>
+    add_docs(<target_suffix> FORMAT <format>
              INPUTS <files or directories> ...
              [OUTPUT <output_directory>])
 
-  The true target name is `${namespace}_${target_alias}` with defined
-  `${target_alias}` variable set to the target name.
+  The true target name is `${namespace}_${target_suffix}`.
 
   See supported formats: https://www.doxygen.nl/manual/starting.html#step2.
 
@@ -44,7 +43,7 @@ enable_if_project_variable_is_set(ENABLE_DOCS)
 
   Also generate install rules for documentation if `${ENABLE_INSTALL}` is set.
 #]=============================================================================]
-function(add_docs target_alias)
+function(add_docs target_suffix)
   set(options "")
   set(one_value_keywords FORMAT OUTPUT)
   set(multi_value_keywords INPUTS)
@@ -69,23 +68,22 @@ function(add_docs target_alias)
   set(DOXYGEN_GENERATE_${ARGS_FORMAT} YES)
   set(DOXYGEN_${ARGS_FORMAT}_OUTPUT "${output}")
 
-  set(target ${namespace}_${target_alias})
   doxygen_add_docs(
-    ${target} ${ARGS_INPUTS}
+    ${namespace}_${target_suffix} ${ARGS_INPUTS}
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
     COMMENT "Generate ${ARGS_FORMAT} documentation"
   )
-  set(${target_alias} ${target} PARENT_SCOPE)
 
   enable_if_project_variable_is_set(ENABLE_INSTALL)
 
+  set(docs_component "${namespace}_docs")
   install(DIRECTORY
       "${output}"
     DESTINATION
       "${INSTALL_DOC_DIR}"
-    COMPONENT "${namespace}_docs" EXCLUDE_FROM_ALL
+    COMPONENT ${docs_component} EXCLUDE_FROM_ALL
   )
-  add_component_target(${namespace}_docs)
+  add_component_target(${docs_component})
 endfunction()
 
 

--- a/install/Common.cmake
+++ b/install/Common.cmake
@@ -116,13 +116,14 @@ function(install_project_cmake_configs)
     ${arch_independent}
   )
 
+  set(configs_component "${namespace}_configs")
   install(FILES
       "${PROJECT_BINARY_DIR}/${config_file}"
       "${PROJECT_BINARY_DIR}/${config_version_file}"
     DESTINATION "${INSTALL_CMAKE_DIR}"
-    COMPONENT "${namespace}_configs"
+    COMPONENT ${configs_component}
   )
-  add_component_target(${namespace}_configs)
+  add_component_target(${configs_component})
 endfunction()
 
 # Install the LICENSE file to `${INSTALL_LICENSE_DIR}`

--- a/install/Common.cmake
+++ b/install/Common.cmake
@@ -134,41 +134,55 @@ macro(install_project_license)
 endmacro()
 
 #[=============================================================================[
-  Install all headers (i.e. *.h and *.hpp files) located in the `base_directory`
-  and its subdirectories recursively to `${CMAKE_INSTALL_INCLUDEDIR}`.
-  The directory structure in the `base_directory` is copied verbatim to the
+  Install all headers (*.h, *.hh, *.h++, *.hpp, *.hxx, *.in, *.inc, and others
+  described in the `PATTERNS` list) located in the `BASE_DIR` and its
+  subdirectories recursively to `${CMAKE_INSTALL_INCLUDEDIR}`.
+  The directory structure in the `BASE_DIR` is copied verbatim to the
   destination.
 
-    install_project_headers([<base_directory>])
+    install_project_headers([BASE_DIR <base_directory>]
+                            [PATTERNS <patterns>...])
 
-  By default, the `base_directory` parameter is `${PROJECT_SOURCE_DIR}/include`.
+  By default, the `BASE_DIR` parameter is `${PROJECT_SOURCE_DIR}/include`.
   Set the install component to `${namespace}_headers`.
 #]=============================================================================]
 function(install_project_headers)
-  if (ARGC EQUAL "0")
-    set(base_directory "include")
-  else()
-    set(base_directory "${ARGV0}")
-  endif()
-
-  if (NOT IS_ABSOLUTE "${base_directory}")
-    set(base_directory "${PROJECT_SOURCE_DIR}/${base_directory}")
-  endif()
-
-  install(DIRECTORY
-      "${base_directory}/"
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-    COMPONENT "${namespace}_headers"
-    FILES_MATCHING
-      PATTERN "*.h"
-      PATTERN "*.hh"
-      PATTERN "*.h++"
-      PATTERN "*.hpp"
-      PATTERN "*.hxx"
-      PATTERN "*.in"
-      PATTERN "*.inc"
+  set(options "")
+  set(one_value_keywords BASE_DIR)
+  set(multi_value_keywords PATTERNS)
+    cmake_parse_arguments(PARSE_ARGV 0 "ARGS"
+    "${options}"
+    "${one_value_keywords}"
+    "${multi_value_keywords}"
   )
-  add_component_target(${namespace}_headers)
+
+  if (NOT ARGS_BASE_DIR)
+    set(ARGS_BASE_DIR "include")
+  endif()
+
+  if (NOT IS_ABSOLUTE "${ARGS_BASE_DIR}")
+    set(ARGS_BASE_DIR "${PROJECT_SOURCE_DIR}/${ARGS_BASE_DIR}")
+  endif()
+
+  list(APPEND ARGS_PATTERNS
+    "*.h"
+    "*.hh"
+    "*.h++"
+    "*.hpp"
+    "*.hxx"
+    "*.in"
+    "*.inc"
+  )
+  list(TRANSFORM ARGS_PATTERNS PREPEND "PATTERN;")
+
+  set(headers_component "${namespace}_headers")
+  install(DIRECTORY
+      "${ARGS_BASE_DIR}/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    COMPONENT ${headers_component}
+    FILES_MATCHING ${ARGS_PATTERNS}
+  )
+  add_component_target(${headers_component})
 endfunction()
 
 #[=============================================================================[

--- a/install/Common.cmake
+++ b/install/Common.cmake
@@ -230,36 +230,40 @@ function(install_project_targets)
 
   set(artifact_options "")
   if (NOT ARGS_HEADER_ONLY)
+    set(runtime_component "${namespace}_runtime")
+    set(development_component "${namespace}_development")
     list(APPEND artifact_options
       RUNTIME
         DESTINATION "${CMAKE_INSTALL_BINDIR}"
-        COMPONENT "${namespace}_runtime"
+        COMPONENT ${runtime_component}
       LIBRARY
         DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        COMPONENT "${namespace}_runtime"
-        NAMELINK_COMPONENT "${namespace}_development"
+        COMPONENT ${runtime_component}
+        NAMELINK_COMPONENT ${development_component}
       ARCHIVE
         DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        COMPONENT "${namespace}_development"
+        COMPONENT ${development_component}
     )
-    add_component_target(${namespace}_runtime)
-    add_component_target(${namespace}_development)
+    add_component_target(${runtime_component})
+    add_component_target(${development_component})
   endif()
 
   install(TARGETS
       ${target_list}
     EXPORT "${PACKAGE_EXPORT_TARGET_NAME}"
+    CONFIGURATIONS "Release"
     ${artifact_options}
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   )
 
+  set(configs_component "${namespace}_configs")
   install(EXPORT
       "${PACKAGE_EXPORT_TARGET_NAME}"
     NAMESPACE ${namespace}::
     DESTINATION "${INSTALL_CMAKE_DIR}"
-    COMPONENT "${namespace}_configs"
+    COMPONENT ${configs_component}
   )
-  add_component_target(${namespace}_configs)
+  add_component_target(${configs_component})
 endfunction()
 
 

--- a/install/Common.cmake
+++ b/install/Common.cmake
@@ -13,6 +13,8 @@
       - install_project_targets
     * Auxiliary commands:
       - add_component_target
+      - append_install_project_target
+      - get_install_project_targets
 
 #]=============================================================================]
 
@@ -187,10 +189,12 @@ function(install_project_headers)
 endfunction()
 
 #[=============================================================================[
-  Install `targets` to specific destinations (see below). Generate and install
+  Install `targets` and install targets from the `${PROJECT_SOURCE_DIR}`
+  directory property `${NAMESPACE}_INSTALL_PROJECT_TARGETS` to specific
+  destinations (see below). Generate and install
   `${PACKAGE_EXPORT_TARGET_NAME}.cmake` file.
 
-    install_project_targets(TARGETS <targets>... [HEADER_ONLY])
+    install_project_targets([TARGETS <targets>...] [HEADER_ONLY])
 
   `HEADER_ONLY` option is used to exclude installation of other artifacts. It
   actually doesn't make headers install, only exports the corresponding
@@ -215,10 +219,6 @@ function(install_project_targets)
     "${multi_value_keywords}"
   )
 
-  if (NOT ARGS_TARGETS)
-    message(FATAL_ERROR "The `TARGETS` parameters must have at least one target.")
-  endif()
-
   set(target_list "")
   foreach (target IN LISTS ARGS_TARGETS)
     __get_project_target_name(${target})
@@ -227,6 +227,13 @@ function(install_project_targets)
     endif()
     list(APPEND target_list ${target})
   endforeach()
+
+  get_install_project_targets()
+  list(APPEND target_list ${install_project_targets})
+
+  if (NOT target_list)
+    message(FATAL_ERROR "There are no targets to install.")
+  endif()
 
   set(artifact_options "")
   if (NOT ARGS_HEADER_ONLY)
@@ -297,3 +304,22 @@ function(add_component_target component)
     )
   endif()
 endfunction()
+
+function(append_install_project_target target)
+  __get_project_target_name(${target})
+  set_property(DIRECTORY
+      "${PROJECT_SOURCE_DIR}"
+    APPEND PROPERTY
+      ${NAMESPACE}_INSTALL_PROJECT_TARGETS
+      ${target}
+  )
+endfunction()
+
+macro(get_install_project_targets)
+  get_property(install_project_targets
+    DIRECTORY
+      "${PROJECT_SOURCE_DIR}"
+    PROPERTY
+      ${NAMESPACE}_INSTALL_PROJECT_TARGETS
+  )
+endmacro()


### PR DESCRIPTION
Issue #23

Changelog:
- Improved installation. The `add_project_*` commands takes the `EXCLUDE_FROM_INSTALLATION` option to exclude the project target from installation, if `${NAMESPACE}_ENABLE_INSTALL` is not already turn off. Otherwise, each project target is added to the `${PROJECT_SOURCE_DIR}` directory property, which is used in the `install_project_targets` command.